### PR TITLE
Add glossary

### DIFF
--- a/content/1_intro.tex
+++ b/content/1_intro.tex
@@ -7,6 +7,8 @@ You can also write footnotes.\footnote{Footnotes will be positioned automaticall
 \blindtext
 
 \section{This is an Important Section}
+
+It is possible to reference glossary entries as \gls{library} as an example.
 \blindtext
 
 \subsection{And an even more important subsection}

--- a/glossary.tex
+++ b/glossary.tex
@@ -1,0 +1,16 @@
+\newglossaryentry{library}
+{
+    name={library},
+    description={A suite of reusable code inside of a programming language for software development}
+}
+
+
+\newglossaryentry{shell}
+{
+    name={shell},
+    description={Terminal of a Linux/Unix system for entering commands}
+}
+
+
+
+\glsaddall

--- a/thesis.tex
+++ b/thesis.tex
@@ -57,6 +57,7 @@
 \usepackage{makeidx}
 \usepackage{paralist,ifthen,todonotes}
 \usepackage{url}
+\usepackage[toc]{glossaries}
 \usepackage{pdfpages}
 
 % table setup
@@ -126,6 +127,9 @@
 % TODO remove if not needed...
 \usepackage{blindtext}
 
+% load glossary entries
+\makenoidxglossaries
+\loadglsentries{glossary}
 
 \begin{document}
 
@@ -168,5 +172,7 @@
 
 \bibliographystyle{wmaainf}
 \bibliography{refs}
+
+\printnoidxglossaries
 
 \end{document}


### PR DESCRIPTION
Every qualified Bachelor Thesis in Computer Science requires a glossary.

I am using the method with the following:

```
\usepackage[toc]{glossaries} %toc for listing in content table
\makenoidxglossaries
\loadglsentries{glossary} %adding file glossary.tex into the same directory

\printnoidxglossaries
```

The file glossary.tex contains two example glossary entries. One of them is referenced in 1_intro.tex.