### PR TITLE
Fixed scrbook error caused by egregdoesnotlikesansseriftitles.

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,7 +1,7 @@
 \documentclass[
     11pt,
     a4paper,
-    egregdoesnotlikesansseriftitles,
+    sfdefaults=false,
     toc=chapterentrywithdots,
     twoside,openright,
     titlepage,


### PR DESCRIPTION
'egregdoesnotlikesansseriftitles' is going to be removed or deprecated and shouldn't be used anymore. 
The pdflatex error output suggests using 'sfdefaults=false' instead.

The problem occurs on a 2017 MacBook with a fresh installation of MiKTeX and the LaTeX Workshop extension in Visual Studio Code.