### PR TITLE
replace bad link to Pruefungsrechtliche Erklaerung

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -138,9 +138,9 @@
 \frontmatter
 \include{cover}\cleardoublepage
 
-% download the following form and complete it (hit save in your editor)
-% https://intern.ohmportal.de/fileadmin/Gelenkte_Doks/Abt/SZS/SB/SB_0050_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf
-%\includepdf{SB_0050_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf}\cleardoublepage
+% download the following form (requires VPN) and complete it (hit save in your editor)
+% https://intern.ohmportal.de/fileadmin/Public_Docs/SB/SB_0009_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf
+%\includepdf{https://intern.ohmportal.de/fileadmin/Public_Docs/SB/SB_0009_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf}\cleardoublepage
 
 \include{content/0_abstract}\cleardoublepage
 

--- a/thesis.tex
+++ b/thesis.tex
@@ -140,7 +140,7 @@
 
 % download the following form (requires VPN) and complete it (hit save in your editor)
 % https://intern.ohmportal.de/fileadmin/Public_Docs/SB/SB_0009_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf
-%\includepdf{https://intern.ohmportal.de/fileadmin/Public_Docs/SB/SB_0009_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf}\cleardoublepage
+%\includepdf{SB_0009_FO_Pruefungsrechtliche_Erklaerung_und_Erklaerung_zur_Veroeffentlichung_der_Abschlussarbeit_public.pdf}\cleardoublepage
 
 \include{content/0_abstract}\cleardoublepage
 


### PR DESCRIPTION
replaces the now dead link to "pruefungsrechtliche erklaerung" with the new official working one.
New documents seem identical in content.