### PR TITLE
Add PDF/A compliance

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -1,3 +1,4 @@
+\pdfminorversion=7
 \documentclass[
     11pt,
     a4paper,
@@ -66,18 +67,20 @@
 \usepackage{ragged2e}
 \usepackage{lscape}
 
-% pdf hyperref
-\usepackage[
-    bookmarks=true,
+% PDF/A compliance
+\begin{filecontents*}{\jobname .xmpdata}
+\Title{\titel}
+\Author{\autor}
+\Subject{\titel}
+\Keywords{\keywords} 
+\Creator{\autor}
+\end{filecontents*}
+
+\usepackage[a-3b,mathxmp]{pdfx}
+\hypersetup{
     bookmarksopen=true,
     bookmarksnumbered=true,
     bookmarksopenlevel=1,
-    pdftitle={\titel},
-    pdfauthor={\autor},
-    pdfcreator={\autor},
-    pdfsubject={\titel},
-    pdfkeywords={\keywords},
-    pdfpagelabels=true,
     colorlinks=true,
     linkcolor=red,
     urlcolor=magenta,
@@ -87,8 +90,8 @@
     menucolor=red,
     plainpages=false,
     hypertexnames=true,
-    linktocpage=true,
-]{hyperref}
+    linktocpage=true
+}
 
 % configure your listings style
 \usepackage{listings}


### PR DESCRIPTION
This PR introduces the **pdfx** LaTeX package to automatically create PDF/A compliant PDFs from the thesis template.

It is one possible solution for issue #17 

**pdfx documentation:**  https://ctan.org/pkg/pdfx?lang=en

Solution description:
pdfx automatically introduces mechanisms that make the PDF mostly PDF/A standards compliant, in the below version specifically PDF/A 3-b (basic) compliant. It additionally supports 1b, 2b and PDF/X.

pdfx internally imports hyperref so the existing import had to be removed and most of the previous settings were added via \hypersetup{...}

pdfx relies on a jobname.xmpdata file to set the correct PDF metadata such as author and title. 
Previously this was set during the import of the hyperref package, now it is set from line 71 to 77 by creating the .xmpdata dynamically based on the same varibles

PDF/A compliance can for example be checked in Adobe Acrobat Pro or, for now, on this website https://www.pdf-online.com/osa/validate.aspx for free